### PR TITLE
Remove length limit from hashtag and consistent return

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,15 +78,16 @@ exports.isMsgLink = function (s) {
 }
 
 
-var normalizeChannel = exports.normalizeChannel =
-  function (data) {
-    if (typeof data === 'string') {
-      data = data.toLowerCase().replace(/\s|,|\.|\?|!|<|>|\(|\)|\[|\]|"|#/g, '')
-      if (data.length > 0 && data.length < 30) {
-        return data
-      }
+exports.normalizeChannel = function (data) {
+  if (typeof data === 'string') {
+    data = data.toLowerCase().replace(/\s|,|\.|\?|!|<|>|\(|\)|\[|\]|"|#/g, '')
+    if (data.length > 0) {
+      return data
     }
   }
+
+  return null
+}
 
 function deprecate (name, fn) {
   var logged = false


### PR DESCRIPTION
## before

- hashtags had a maximum length of 30 characters
- invalid hashtags would accidentally return `undefined`

## after

- hashtags have no maximum length
- invalid hashtags will intentionally return `null`