### PR TITLE
Add basic .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+
+node_js:
+  - lts/dubnium
+  - lts/erbium
+  - node
+
+os:
+  - linux
+  - osx
+  - windows
+
+git:
+  autocrlf: input


### PR DESCRIPTION
We aren't doing any automated testing, which makes it hard to know
whether a patch should be merged or not without running it on your
computer.

This patch resolves the problem by adding a basic Travis config that
runs on Node 10, 12, and latest -- on Windows, MacOS, and Linux.