### PR TITLE
Fix normalizeChannel()

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,10 +85,11 @@ var normalizeChannel = exports.normalizeChannel =
   function (data) {
     if (typeof data === 'string') {
       data = data.toLowerCase().replace(/\s|,|\.|\?|!|<|>|\(|\)|\[|\]|"|#/g, '')
-      if (data.length > 0 && data.length < 30) {
-        return data
+      if (data.length > 0) {
+        return data.slice(0, 30)
       }
     }
+    return null
   }
 
 function deprecate (name, fn) {

--- a/test/channels.js
+++ b/test/channels.js
@@ -1,0 +1,23 @@
+const tape = require('tape')
+const { normalizeChannel } = require('../')
+
+tape('happy path', (assert) => {
+  assert.equal(normalizeChannel('hello'), 'hello')
+  assert.equal(normalizeChannel('WORLD'), 'world')
+  assert.equal(normalizeChannel('👍👍👍'), '👍👍👍')
+  assert.equal(normalizeChannel('!@#$%^&*()_'), '@$%^&*_')
+  assert.end()
+})
+
+tape('truncate', (assert) => {
+  assert.equal(normalizeChannel('a'.repeat(63)), 'a'.repeat(30))
+  assert.equal(normalizeChannel('A'.repeat(63)), 'a'.repeat(30))
+  assert.end()
+})
+
+tape('failure', (assert) => {
+  assert.equal(normalizeChannel(''), null)
+  assert.equal(normalizeChannel(42), null)
+  assert.equal(normalizeChannel('!#()'), null)
+  assert.end()
+})


### PR DESCRIPTION
Any time the constraints of `normalizeChannel()` are violated it returns
`undefined`, which is rarely what we want.

This commit changes the behavior so that channels that can't be
normalized return `null`, and channels that are too long become
truncated. This should lower the prevelance of `#undefined` in
user-facing applications.

See-also: https://github.com/ssb-js/ssb-ref/pull/33