### PR TITLE
catch throw when decoding malformed multserver-address's

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ or a legacy address, or if `object` is a parsed legacy address
 
 returns a feed id of the address in this key.
 (assumes there is a `shs:` protocol in the address,
-including accepts future version of shs)
+including accepts future version of shs).
+
+returns `undefined` if it fails to parse a key.
 
 ### isInvite(invite)
 

--- a/index.js
+++ b/index.js
@@ -175,7 +175,11 @@ var isAddress = exports.isAddress = function (data) {
 // extraction of a signing key from the address.
 exports.getKeyFromAddress = function (addr) {
   if (addr.key) return addr.key
-  var data = MultiServerAddress.decode(addr)
+  try {
+    var data = MultiServerAddress.decode(addr)
+  } catch (err) {
+    console.error(new Error('Attempted connection with malformed multiserver-address ' + addr))
+  }
   if (!data) return
   for (var k in data) {
     var address = data[k]

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ exports.getKeyFromAddress = function (addr) {
   } catch (err) {
     console.error(new Error('Attempted connection with malformed multiserver-address ' + addr))
   }
-  if (!data) return
+  if (!data) return undefined
   for (var k in data) {
     var address = data[k]
     for (var j in address) {

--- a/test/invites.js
+++ b/test/invites.js
@@ -100,4 +100,11 @@ tape('legacy invite', function (t) {
       redirect: '#' + rand
     })
   t.end()
+
+  tape('handle non `shs` protocol invites', (t) => {
+    t.doesNotThrow(() => {
+      R.getKeyFromAddress('INVITE sip:0019294040830@51.15.166.54:8008 SIP/2.0')
+    })
+    t.end()
+  })
 })


### PR DESCRIPTION
I think this is all that's needed to fix https://github.com/ssb-js/ssb-ref/issues/39  and also https://github.com/fraction/oasis/issues/418. 

Not sure if printing the error is what is best or if something more quiet would be better?